### PR TITLE
Redesign builds tab

### DIFF
--- a/src/components/builds-tab/BuildsTabPage.vue
+++ b/src/components/builds-tab/BuildsTabPage.vue
@@ -1,51 +1,18 @@
 <template>
   <div class="builds-tab-page tab-page">
     <div
-        class="banner"
-        v-if="!verifyBannerHidden"
-    >
-      <div class="text">
-        You can verify that a file has not been tampered with by checking its signature.
-      </div>
-      <div class="buttons">
-        <a
-            class="button"
-            href="https://wiki.lineageos.org/verifying-builds.html"
-            target="_blank"
-        >
-          Learn more
-          <span class="mdi mdi-open-in-new"></span>
-        </a>
-        <a
-            class="button"
-            v-on:click="hideVerifyBanner"
-        >
-          Got it
-        </a>
-      </div>
-    </div>
-    <div
-      class="banner"
-      v-if="!additionalImagesBannerHidden"
-    >
-      <div class="text">
-        Not all images are necessary for installation or upgrades. Please follow the instructions for your device!
-      </div>
-      <div class="buttons">
-        <a
-            class="button"
-            v-on:click="hideAdditionalImagesBanner"
-        >
-          Got it
-        </a>
-      </div>
-    </div>
-    <div
         class="list-container"
         data-simplebar
         v-if="builds.length > 0"
     >
       <div class="list">
+        <div class="header">
+          <h1>Download builds</h1>
+          <p>Not all images are necessary for installation or upgrades. Check your device's <a v-bind:href="info_url" target="_blank">wiki guides</a>
+          for more info.<br/>
+          You can verify that a file has not been tampered by <a href="https://wiki.lineageos.org/verifying-builds.html" target="_blank">checking its signature</a>.</p>
+        </div>
+        <div class="list-label">Latest</div>
         <template v-for="build in builds">
           <downloadable-group
               v-bind="{
@@ -93,8 +60,6 @@ export default {
   data() {
     return {
       builds: [],
-      verifyBannerHidden: false,
-      additionalImagesBannerHidden: false,
     };
   },
   beforeRouteEnter: loadDeviceBuildsBeforeHook,
@@ -105,25 +70,10 @@ export default {
     },
   },
   mounted() {
-    this.verifyBannerHidden = this.isVerifyBannerHidden();
-    this.additionalImagesBannerHidden = this.isAdditionalImagesBannerHidden();
     this.loadBuilds();
+    this.loadDeviceDetails();
   },
   methods: {
-    isVerifyBannerHidden() {
-      return localStorage.getItem(VERIFY_BUILD_BANNER_HIDE) === '1';
-    },
-    hideVerifyBanner() {
-      localStorage.setItem(VERIFY_BUILD_BANNER_HIDE, '1');
-      this.verifyBannerHidden = true;
-    },
-    isAdditionalImagesBannerHidden() {
-      return localStorage.getItem(ADDITIONAL_IMAGES_BANNER_HIDE) === '1';
-    },
-    hideAdditionalImagesBanner() {
-      localStorage.setItem(ADDITIONAL_IMAGES_BANNER_HIDE, '1');
-      this.additionalImagesBannerHidden = true;
-    },
     async loadBuilds() {
       const data = this.$store.getters.getDeviceBuilds(this.model);
       if (!data) {
@@ -132,83 +82,22 @@ export default {
 
       this.builds = data;
     },
+    loadDeviceDetails() {
+      const data = this.$store.getters.getDevice(this.model);
+      if (!data) {
+        throw new Error('Failed to get device-main data');
+      }
+
+      [
+        'info_url',
+      ].forEach(k => this[k] = data[k]);
+    },
   },
 }
 </script>
 
 <style scoped>
 @import '../../css/tab-page.css';
-
-.builds-tab-page .banner {
-  flex-shrink: 0;
-
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-
-  line-height: 24px;
-
-  padding: 16px 16px 15px 16px;
-
-  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
-}
-
-#app.dark .builds-tab-page .banner {
-  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
-}
-
-.builds-tab-page .banner.hidden {
-  display: none;
-}
-
-.builds-tab-page .banner .text {
-  padding: 4px 0;
-}
-.builds-tab-page .banner .buttons {
-  text-decoration: none;
-  text-transform: uppercase;
-  line-height: 32px;
-  font-size: 14px;
-  font-weight: 500;
-  white-space: nowrap;
-}
-
-.builds-tab-page .banner .button {
-  padding: 0 16px;
-  margin: 0 8px;
-  border-radius: 2px;
-
-  display: inline-block;
-  vertical-align: top;
-
-  color: #167c80;
-  text-decoration: none;
-
-  transition: background 0.25s ease-out;
-
-  cursor: pointer;
-  user-select: none;
-}
-
-@media (hover: hover) {
-  .builds-tab-page .banner .button:hover {
-    background: rgba(22, 124, 128, 0.15);
-  }
-}
-
-.builds-tab-page .banner .button:active {
-  background: rgba(22, 124, 128, 0.35);
-}
-
-@media (max-width: 1024px) {
-  .builds-tab-page .banner {
-    display: block;
-  }
-
-  .builds-tab-page .banner .buttons {
-    text-align: right;
-  }
-}
 
 .builds-tab-page .list-placeholder {
   display: flex;
@@ -222,6 +111,73 @@ export default {
 .builds-tab-page .list-placeholder a {
   text-decoration: none;
   color: #167c80;
+}
+
+.builds-tab-page .header {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 40px 24px;
+  gap: 16px;
+}
+
+.builds-tab-page .header h1 {
+  flex: none;
+  align-self: stretch;
+  font-size: 32px;
+  line-height: 38px;
+  margin: 0;
+  font-weight: 500;
+}
+
+.builds-tab-page .header p {
+  flex: none;
+  order: 1;
+  align-self: stretch;
+  flex-grow: 0;
+}
+
+.builds-tab-page .header a {
+  color: #167c80;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.builds-tab-page .list-label {
+  font-size: 24px;
+  line-height: 28px;
+  padding: 0px 24px 16px;
+  font-weight: 500;
+}
+
+@media (max-width: 479px) {
+  .builds-tab-page .header {
+    padding: 40px 16px;
+  }
+
+  .builds-tab-page .list-label {
+    padding: 0px 16px 16px;
+  }
+}
+
+div.group:nth-child(3) {
+  border: 1px solid rgba(0, 0, 0, 0.25) !important;
+  border-radius: 16px;
+}
+
+#app.dark div.group:nth-child(3) {
+  border: 1px solid rgba(255, 255, 255, 0.25) !important;
+  border-radius: 16px;
+}
+
+.group {
+  padding: 24px 18px 24px 24px;
+}
+
+@media (max-width: 479px) {
+  .group {
+    padding: 16px 10px 16px 16px;
+  }
 }
 
 </style>

--- a/src/components/downloadable/Downloadable.vue
+++ b/src/components/downloadable/Downloadable.vue
@@ -18,39 +18,46 @@
           {{ name || filename }}
         </div>
         <div class="controls">
+          <a v-bind:href="url" class="download-icon">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M2 16C1.45 16 0.979333 15.8043 0.588 15.413C0.196 15.021 0 14.55 0 14V11H2V14H14V11H16V14C16
+              14.55 15.8043 15.021 15.413 15.413C15.021 15.8043 14.55 16 14 16H2ZM8 12L3 7L4.4 5.55L7 8.15V0H9V8.15L11.6 5.55L13 7L8 12Z"
+              fill="currentColor"/>
+            </svg>
+          </a>
           <i
-              class="mdi mdi-information icon expand-icon"
+              class="mdi icon expand-icon"
+              :class="{'mdi-information': isExpanded, 'mdi-information-outline': !isExpanded}"
               v-on:click="toggleManualExpansion"
           ></i>
-          <a
-              class="mdi mdi-download icon"
-              v-bind:href="url"
-          ></a>
         </div>
       </div>
     </template>
     <template v-slot:content>
-      <div class="details">
-        <downloadable-detail
-            title="Date"
-            v-if="date"
-            v-bind:value="date"
-        ></downloadable-detail>
-        <downloadable-detail
-            title="Type"
-            v-if="type"
-            v-bind:value="type"
-        ></downloadable-detail>
-        <downloadable-detail
-            title="Size"
-            v-if="sizeHuman"
-            v-bind:value="sizeHuman"
-        ></downloadable-detail>
-        <downloadable-detail
-            title="SHA256"
-            v-if="sha256"
-            v-bind:value="sha256"
-        ></downloadable-detail>
+      <div class="details-wrapper">
+        <div class="details">
+          <span class="details-title">Details</span>
+          <downloadable-detail
+              title="Date"
+              v-if="date"
+              v-bind:value="date"
+          ></downloadable-detail>
+          <downloadable-detail
+              title="Type"
+              v-if="type"
+              v-bind:value="type"
+          ></downloadable-detail>
+          <downloadable-detail
+              title="Size"
+              v-if="sizeHuman"
+              v-bind:value="sizeHuman"
+          ></downloadable-detail>
+          <downloadable-detail
+              title="SHA256"
+              v-if="sha256"
+              v-bind:value="sha256"
+          ></downloadable-detail>
+        </div>
       </div>
     </template>
   </collapsible>
@@ -117,6 +124,8 @@ export default {
 
 .downloadable .title-container .controls {
   display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .downloadable .title-container .controls .icon {
@@ -135,10 +144,43 @@ export default {
   color: rgba(0, 0, 0, 0.56);
 
   cursor: pointer;
+
+  user-select: none; /* prevent automatic selection of the details contents */
 }
 
 #app.dark .downloadable .title-container .controls .icon {
   color: rgba(255, 255, 255, 0.56);
+}
+
+.downloadable .title-container .controls .download-icon {
+  display: flex !important;
+  flex-direction: row;
+  align-items: center;
+  padding: 4px 16px;
+  gap: 10px;
+  background: #CCE8E9;
+  border-radius: 16px;
+  width: 56px;
+  height: 32px;
+  justify-content: center;
+  transition: background 0.125s ease-out;
+}
+
+#app.dark .downloadable .title-container .controls .download-icon {
+  background: #324B4C !important;
+}
+
+.downloadable .title-container .controls .download-icon svg {
+  color: #324B4C !important;
+}
+
+#app.dark .downloadable .title-container .controls .download-icon svg {
+  color: #CCE8E9 !important;
+}
+
+.downloadable .title-container.expanded .controls .expand-icon,
+#app.dark .downloadable .title-container.expanded .controls .expand-icon {
+  color: #167c80;
 }
 
 @media (hover: hover) {
@@ -149,21 +191,47 @@ export default {
   #app.dark .downloadable .title-container .controls .icon:hover {
     background: rgba(255, 255, 255, 0.15);
   }
+
+  .downloadable .title-container .controls .download-icon:hover {
+    background: #167c80 !important;
+  }
+
+  #app.dark .downloadable .title-container .controls .download-icon:hover {
+    background: #167c80 !important;
+  }
+
+  .downloadable .title-container .controls .download-icon:hover svg {
+    color: #FFF !important;
+    transition: background 0.125s ease-out;
+  }
+
+  #app.dark .downloadable .title-container .controls .download-icon:hover svg {
+    color: #FFF !important;
+    transition: background 0.125s ease-out;
+  }
 }
 
-.downloadable .title-container.expanded .controls .expand-icon,
-#app.dark .downloadable .title-container.expanded .controls .expand-icon {
-  color: #167c80;
+.downloadable .details-wrapper {
+  margin-right: 6px;
 }
 
 .downloadable .details {
   line-height: 24px;
-  padding: 4px 8px;
-  border-radius: 3px;
+  padding: 16px;
+  border-radius: 4px;
 
   font-size: 14px;
 
   background: rgba(0, 0, 0, 0.05);
+
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.downloadable .details .details-title {
+  display: flex;
+  line-height: 150%;
 }
 
 #app.dark  .downloadable .details {

--- a/src/components/downloadable/DownloadableDetail.vue
+++ b/src/components/downloadable/DownloadableDetail.vue
@@ -18,7 +18,6 @@ export default {
 <style scoped>
 .downloadable-detail {
   display: flex;
-  padding: 4px 0;
 }
 
 .downloadable-detail .title,
@@ -37,7 +36,7 @@ export default {
 }
 
 .downloadable-detail .value {
-  width: 85%;
+  width: 75%;
   flex-shrink: 0;
   word-wrap: break-word;
 }

--- a/src/css/tab-page.css
+++ b/src/css/tab-page.css
@@ -17,4 +17,5 @@
     min-width: 0;
     max-width: 756px;
     margin: 0 auto;
+    padding: 0 8px;
 }


### PR DESCRIPTION
* Remove banners, once dismissed they won't reappear and one doesn't have any info on how to verify
* Add title and mark the latest build explicitly with a border
* Add a subtitle to the Details collapsible
* Swap Downloads / Info icons, downloads come first
* Redesign download button - we have our own icon now and also make it different to the info icon by looking like a button