### PR TITLE
Run npm ci instead of npm install

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,8 +10,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Run [install, lint, format]
+      - name: Run [ci, lint, format]
         run: |
-          npm install
+          npm ci
           npm run lint
           npm run format -- --check --no-write

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run [ci, lint, format]
         run: |

--- a/fly/Dockerfile
+++ b/fly/Dockerfile
@@ -3,7 +3,7 @@ FROM node:18 as builder
 COPY . /app
 COPY fly/.env.production /app
 WORKDIR /app
-RUN npm install && npm run build
+RUN npm ci && npm run build
 
 FROM caddy:2
 COPY --from=builder /app/dist/ /usr/share/caddy/


### PR DESCRIPTION
Since we already keep package-lock.json