### PR TITLE
Set osPatchLevelHuman date to UTC

### DIFF
--- a/src/components/downloadable/DownloadableItem.vue
+++ b/src/components/downloadable/DownloadableItem.vue
@@ -90,7 +90,8 @@ export default {
       if (this.os_patch_level !== undefined) {
         return new Date(this.os_patch_level).toLocaleString('en-US', {
           month: 'long',
-          year: 'numeric'
+          year: 'numeric',
+          timeZone: 'UTC'
         })
       }
       return ''


### PR DESCRIPTION
This prevents the date being converted to the browser's timezone, which was causing any timezone with a negative offset to show the OS patch level of the previous month.